### PR TITLE
feat: partial loan returns

### DIFF
--- a/__tests__/loan-status.test.ts
+++ b/__tests__/loan-status.test.ts
@@ -30,13 +30,46 @@ describe('deriveLoanStatus', () => {
     expect(deriveLoanStatus(reservations, LoanStatus.ACCEPTED)).toBe(LoanStatus.REJECTED);
   });
 
-  it('should return IN_BOX when any reservation is IN_BOX', () => {
+  it('should return IN_BOX when any reservation is IN_BOX and none are INUSE', () => {
     const reservations = [
       { status: ReservationStatus.ACCEPTED },
       { status: ReservationStatus.IN_BOX },
       { status: ReservationStatus.RETURNED },
     ];
     expect(deriveLoanStatus(reservations, LoanStatus.ACCEPTED)).toBe(LoanStatus.IN_BOX);
+  });
+
+  it('should return PARTIALLY_RETURNED when some are INUSE and some are IN_BOX', () => {
+    const reservations = [
+      { status: ReservationStatus.INUSE },
+      { status: ReservationStatus.IN_BOX },
+    ];
+    expect(deriveLoanStatus(reservations, LoanStatus.INUSE)).toBe(LoanStatus.PARTIALLY_RETURNED);
+  });
+
+  it('should return PARTIALLY_RETURNED when some are INUSE and some are RETURNED', () => {
+    const reservations = [
+      { status: ReservationStatus.INUSE },
+      { status: ReservationStatus.RETURNED },
+    ];
+    expect(deriveLoanStatus(reservations, LoanStatus.INUSE)).toBe(LoanStatus.PARTIALLY_RETURNED);
+  });
+
+  it('should return PARTIALLY_RETURNED for INUSE + IN_BOX + RETURNED mix', () => {
+    const reservations = [
+      { status: ReservationStatus.INUSE },
+      { status: ReservationStatus.IN_BOX },
+      { status: ReservationStatus.RETURNED },
+    ];
+    expect(deriveLoanStatus(reservations, LoanStatus.INUSE)).toBe(LoanStatus.PARTIALLY_RETURNED);
+  });
+
+  it('should return INUSE when some are INUSE and rest are ACCEPTED/REJECTED only', () => {
+    const reservations = [
+      { status: ReservationStatus.INUSE },
+      { status: ReservationStatus.REJECTED },
+    ];
+    expect(deriveLoanStatus(reservations, LoanStatus.ACCEPTED)).toBe(LoanStatus.INUSE);
   });
 
   it('should return INUSE when any reservation is INUSE', () => {
@@ -55,12 +88,12 @@ describe('deriveLoanStatus', () => {
     expect(deriveLoanStatus(reservations, LoanStatus.ACCEPTED)).toBe(LoanStatus.ACCEPTED);
   });
 
-  it('should prioritize IN_BOX over INUSE', () => {
+  it('should return PARTIALLY_RETURNED when mixing INUSE and IN_BOX (not plain IN_BOX)', () => {
     const reservations = [
       { status: ReservationStatus.INUSE },
       { status: ReservationStatus.IN_BOX },
     ];
-    expect(deriveLoanStatus(reservations, LoanStatus.ACCEPTED)).toBe(LoanStatus.IN_BOX);
+    expect(deriveLoanStatus(reservations, LoanStatus.INUSE)).toBe(LoanStatus.PARTIALLY_RETURNED);
   });
 
   it('should not return RETURNED if any reservation is not RETURNED', () => {
@@ -103,6 +136,7 @@ describe('getLoanStatusLabel', () => {
     expect(getLoanStatusLabel(LoanStatus.REJECTED)).toBe('Hylätty');
     expect(getLoanStatusLabel(LoanStatus.INUSE)).toBe('Käytössä');
     expect(getLoanStatusLabel(LoanStatus.IN_BOX)).toBe('Laatikossa');
+    expect(getLoanStatusLabel(LoanStatus.PARTIALLY_RETURNED)).toBe('Osittain palautettu');
     expect(getLoanStatusLabel(LoanStatus.RETURNED)).toBe('Palautettu');
   });
 
@@ -117,6 +151,7 @@ describe('getLoanStatusColor', () => {
     expect(getLoanStatusColor(LoanStatus.REJECTED)).toBe('red');
     expect(getLoanStatusColor(LoanStatus.INUSE)).toBe('blue');
     expect(getLoanStatusColor(LoanStatus.IN_BOX)).toBe('purple');
+    expect(getLoanStatusColor(LoanStatus.PARTIALLY_RETURNED)).toBe('orange');
     expect(getLoanStatusColor(LoanStatus.RETURNED)).toBe('gray');
   });
 });

--- a/pages/admin/editLoan/[id].tsx
+++ b/pages/admin/editLoan/[id].tsx
@@ -191,7 +191,11 @@ export default function LoanEditView({ loan, items }: { loan: LoanWithRelations;
     loan.reservations.map((r) => ({ status: r.status as ReservationStatus })),
     loan.status as LoanStatus,
   );
-  const statusAllowsEdit = derivedStatus !== 'INUSE' && derivedStatus !== 'RETURNED';
+  const statusAllowsEdit =
+    derivedStatus !== 'INUSE' &&
+    derivedStatus !== 'IN_BOX' &&
+    derivedStatus !== 'PARTIALLY_RETURNED' &&
+    derivedStatus !== 'RETURNED';
 
   if (!session?.user || (!isAdmin && !isOwner)) {
     return <NotAuthenticated />;

--- a/pages/api/loan/loanProcessed.ts
+++ b/pages/api/loan/loanProcessed.ts
@@ -1,8 +1,9 @@
-import { LoanStatus, ReservationStatus } from '@prisma/client';
+import { ReservationStatus } from '@prisma/client';
 import prisma from '../../../utils/prisma';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { deriveLoanStatus } from '../../../utils/loanHelpers';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
@@ -13,11 +14,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  const { id } = req.body;
+  const { id, reservationIds } = req.body as { id: string; reservationIds?: string[] };
 
-  // Get the loan
   const loan = await prisma.loan.findUnique({
     where: { id },
+    include: {
+      reservations: { select: { id: true, status: true } },
+    },
   });
 
   if (!loan) {
@@ -25,19 +28,39 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  // Update loan status to RETURNED and remove it from its box
-  // Also update all reservation statuses to RETURNED
+  // Only IN_BOX reservations are eligible to be marked as RETURNED here.
+  // INUSE items are still physically with the borrower and must not be touched.
+  const eligible = loan.reservations.filter((r) => r.status === ReservationStatus.IN_BOX);
+  const targetIds =
+    Array.isArray(reservationIds) && reservationIds.length > 0
+      ? eligible.filter((r) => reservationIds.includes(r.id)).map((r) => r.id)
+      : eligible.map((r) => r.id);
+
+  if (targetIds.length === 0) {
+    res.status(400).json({ message: 'Ei käsiteltäviä tavaroita laatikossa' });
+    return;
+  }
+
+  // Post-update reservation states to compute the new loan status.
+  const updatedReservationStates = loan.reservations.map((r) =>
+    targetIds.includes(r.id) ? { status: ReservationStatus.RETURNED } : { status: r.status },
+  );
+  const newLoanStatus = deriveLoanStatus(updatedReservationStates, loan.status);
+
+  // Clear boxId when no reservations remain in IN_BOX after this update.
+  const hasInBoxRemaining = updatedReservationStates.some(
+    (r) => r.status === ReservationStatus.IN_BOX,
+  );
+
   const result = await prisma.loan.update({
     where: { id },
     data: {
-      status: LoanStatus.RETURNED,
-      boxId: null,
+      status: newLoanStatus,
+      boxId: hasInBoxRemaining ? loan.boxId : null,
       reservations: {
         updateMany: {
-          where: {},
-          data: {
-            status: ReservationStatus.RETURNED,
-          },
+          where: { id: { in: targetIds } },
+          data: { status: ReservationStatus.RETURNED },
         },
       },
     },

--- a/pages/api/loan/loanReturned.ts
+++ b/pages/api/loan/loanReturned.ts
@@ -3,6 +3,7 @@ import prisma from '../../../utils/prisma';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { deriveLoanStatus } from '../../../utils/loanHelpers';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
@@ -13,15 +14,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  const { id } = req.body;
+  const { id, reservationIds } = req.body as { id: string; reservationIds?: string[] };
 
-  // Get the loan with its items
+  // Get the loan with its reservations
   const loan = await prisma.loan.findUnique({
     where: { id },
     include: {
       reservations: {
         select: {
+          id: true,
           itemId: true,
+          status: true,
         },
       },
     },
@@ -32,74 +35,97 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  // Get item IDs from the loan being returned
-  const loanItemIds = new Set(loan.reservations.map((r) => r.itemId));
+  // Determine which reservations to mark as IN_BOX.
+  // Only INUSE reservations are eligible (can't re-return something already in a box).
+  const eligible = loan.reservations.filter((r) => r.status === ReservationStatus.INUSE);
+  const targetIds =
+    Array.isArray(reservationIds) && reservationIds.length > 0
+      ? eligible.filter((r) => reservationIds.includes(r.id)).map((r) => r.id)
+      : eligible.map((r) => r.id);
 
-  // Find all boxes with their loans and items
-  const boxes = await prisma.box.findMany({
-    include: {
-      loans: {
-        where: {
-          status: LoanStatus.IN_BOX,
-        },
-        include: {
-          reservations: {
-            select: {
-              itemId: true,
+  if (targetIds.length === 0) {
+    res.status(400).json({ message: 'Ei palautettavia tavaroita' });
+    return;
+  }
+
+  // Pick the box. If this loan is already assigned to a box (because of a
+  // previous partial return), reuse it so the loan's items stay together.
+  let selectedBox: { id: string; name: string; description: string | null } | null = null;
+
+  if (loan.boxId) {
+    selectedBox = await prisma.box.findUnique({
+      where: { id: loan.boxId },
+      select: { id: true, name: true, description: true },
+    });
+  }
+
+  if (!selectedBox) {
+    // Target item IDs for box-selection heuristics (only the items currently being returned).
+    const loanItemIds = new Set(
+      loan.reservations.filter((r) => targetIds.includes(r.id)).map((r) => r.itemId),
+    );
+
+    const boxes = await prisma.box.findMany({
+      include: {
+        loans: {
+          where: { status: { in: [LoanStatus.IN_BOX, LoanStatus.PARTIALLY_RETURNED] } },
+          include: {
+            reservations: {
+              where: { status: ReservationStatus.IN_BOX },
+              select: { itemId: true },
             },
           },
         },
       },
-    },
-  });
-
-  if (boxes.length === 0) {
-    res.status(400).json({ message: 'No boxes available' });
-    return;
-  }
-
-  // Strategy 1: Find a box with no loans (empty box)
-  const emptyBox = boxes.find((box) => box.loans.length === 0);
-  let selectedBox;
-  if (emptyBox) {
-    selectedBox = emptyBox;
-  } else {
-    // Strategy 2: Find a box with no overlapping items
-    const loanItemIdsArray = Array.from(loanItemIds);
-    const boxesWithNoOverlap = boxes.filter((box) => {
-      const boxItemIds = new Set(
-        box.loans.flatMap((loan) => loan.reservations.map((r) => r.itemId)),
-      );
-      // Check if there's no intersection between loan items and box items
-      return !loanItemIdsArray.some((itemId) => boxItemIds.has(itemId));
     });
 
-    if (boxesWithNoOverlap.length > 0) {
-      // Select the one with fewest loans
-      selectedBox = boxesWithNoOverlap.reduce((prev, current) =>
-        current.loans.length < prev.loans.length ? current : prev,
-      );
+    if (boxes.length === 0) {
+      res.status(400).json({ message: 'No boxes available' });
+      return;
+    }
+
+    // Strategy 1: empty box (no loans currently assigned)
+    const emptyBox = boxes.find((box) => box.loans.length === 0);
+    if (emptyBox) {
+      selectedBox = emptyBox;
     } else {
-      // Strategy 3: Fallback to box with fewest loans
-      selectedBox = boxes.reduce((prev, current) =>
-        current.loans.length < prev.loans.length ? current : prev,
-      );
+      // Strategy 2: box with no overlapping IN_BOX items
+      const loanItemIdsArray = Array.from(loanItemIds);
+      const boxesWithNoOverlap = boxes.filter((box) => {
+        const boxItemIds = new Set(
+          box.loans.flatMap((l) => l.reservations.map((r) => r.itemId)),
+        );
+        return !loanItemIdsArray.some((itemId) => boxItemIds.has(itemId));
+      });
+
+      if (boxesWithNoOverlap.length > 0) {
+        selectedBox = boxesWithNoOverlap.reduce((prev, current) =>
+          current.loans.length < prev.loans.length ? current : prev,
+        );
+      } else {
+        // Strategy 3: fallback to box with fewest loans
+        selectedBox = boxes.reduce((prev, current) =>
+          current.loans.length < prev.loans.length ? current : prev,
+        );
+      }
     }
   }
 
-  // Update loan status to IN_BOX and assign it to the selected box
-  // Also update all reservation statuses to IN_BOX
+  // Compute the new derived loan status based on the post-update reservation states.
+  const updatedReservationStates = loan.reservations.map((r) =>
+    targetIds.includes(r.id) ? { status: ReservationStatus.IN_BOX } : { status: r.status },
+  );
+  const newLoanStatus = deriveLoanStatus(updatedReservationStates, loan.status);
+
   const result = await prisma.loan.update({
     where: { id },
     data: {
-      status: LoanStatus.IN_BOX,
+      status: newLoanStatus,
       boxId: selectedBox.id,
       reservations: {
         updateMany: {
-          where: {},
-          data: {
-            status: ReservationStatus.IN_BOX,
-          },
+          where: { id: { in: targetIds } },
+          data: { status: ReservationStatus.IN_BOX },
         },
       },
     },

--- a/pages/kiosk/return.tsx
+++ b/pages/kiosk/return.tsx
@@ -102,7 +102,10 @@ const LoanReturnCard = ({
   onReturnComplete,
 }: {
   loan: LoanType;
-  onReturn: (id: string) => Promise<{ name: string; description: string | null } | null>;
+  onReturn: (
+    id: string,
+    reservationIds: string[],
+  ) => Promise<{ name: string; description: string | null } | null>;
   onReturnComplete: () => void;
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -119,6 +122,32 @@ const LoanReturnCard = ({
   const [termsAccepted, setTermsAccepted] = React.useState(false);
 
   const [reportContent, setReportContent] = React.useState('');
+
+  // Only show INUSE reservations in the return flow
+  const inuseReservations = React.useMemo(
+    () => loan.reservations.filter((r) => r.status === ReservationStatus.INUSE),
+    [loan.reservations],
+  );
+
+  // Selected reservations to return. Default: all INUSE items checked.
+  const [selectedIds, setSelectedIds] = React.useState<Set<string>>(
+    () => new Set(inuseReservations.map((r) => r.id)),
+  );
+
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const allSelected = selectedIds.size === inuseReservations.length;
+  const isPartialReturn = selectedIds.size > 0 && selectedIds.size < inuseReservations.length;
   // Move useColorModeValue calls to top level of component
   const itemBg = useColorModeValue('gray.50', 'gray.700');
   const itemBorderColor = useColorModeValue('gray.200', 'gray.600');
@@ -133,7 +162,7 @@ const LoanReturnCard = ({
   const infoBorder = useColorModeValue('gray.300', 'gray.600');
 
   const handleConfirmReturn = async () => {
-    const box = await onReturn(loan.id);
+    const box = await onReturn(loan.id, Array.from(selectedIds));
     if (box) {
       setBoxInfo(box);
       onClose();
@@ -166,9 +195,6 @@ const LoanReturnCard = ({
 
   // Derive the loan status from reservations
   const derivedStatus = deriveLoanStatus(loan.reservations, loan.status);
-
-  // Only show INUSE reservations in the return flow
-  const inuseReservations = loan.reservations.filter((r) => r.status === ReservationStatus.INUSE);
 
   return (
     <>
@@ -211,32 +237,65 @@ const LoanReturnCard = ({
                 Palautat kamoja
               </Heading>
 
+              <Text fontSize="md" textAlign="center" color={subtleText}>
+                Valitse mitkä tavarat palautat. Jos sinulla ei ole kaikkia käsillä, voit palauttaa
+                osan nyt ja loput myöhemmin.
+              </Text>
+
               <VStack spacing={4} align="stretch">
-                {inuseReservations.map((reservation) => (
-                  <HStack
-                    key={reservation.id}
-                    p={4}
-                    bg={itemBg}
-                    borderRadius="lg"
-                    borderWidth="2px"
-                    borderColor={itemBorderColor}
-                    spacing={4}
-                  >
-                    <ReservationItemImage
-                      itemId={reservation.item.id}
-                      itemName={reservation.item.name}
-                    />
-                    <VStack align="start" spacing={1} flex={1}>
-                      <Text fontSize="lg" fontWeight="bold">
-                        {reservation.item.name}
-                      </Text>
-                      <Text fontSize="md" color={subtleText}>
-                        Määrä: {reservation.amount} kpl
-                      </Text>
-                    </VStack>
-                  </HStack>
-                ))}
+                {inuseReservations.map((reservation) => {
+                  const checked = selectedIds.has(reservation.id);
+                  return (
+                    <HStack
+                      key={reservation.id}
+                      p={4}
+                      bg={itemBg}
+                      borderRadius="lg"
+                      borderWidth="2px"
+                      borderColor={checked ? 'green.400' : itemBorderColor}
+                      spacing={4}
+                      onClick={() => toggleSelected(reservation.id)}
+                      cursor="pointer"
+                    >
+                      <Checkbox
+                        size="lg"
+                        isChecked={checked}
+                        onChange={() => toggleSelected(reservation.id)}
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                      <ReservationItemImage
+                        itemId={reservation.item.id}
+                        itemName={reservation.item.name}
+                      />
+                      <VStack align="start" spacing={1} flex={1}>
+                        <Text fontSize="lg" fontWeight="bold">
+                          {reservation.item.name}
+                        </Text>
+                        <Text fontSize="md" color={subtleText}>
+                          Määrä: {reservation.amount} kpl
+                        </Text>
+                      </VStack>
+                    </HStack>
+                  );
+                })}
               </VStack>
+
+              {isPartialReturn && (
+                <Box
+                  p={4}
+                  bg={infoBg}
+                  borderRadius="lg"
+                  borderWidth="2px"
+                  borderColor="orange.300"
+                >
+                  <Text fontSize="md" fontWeight="bold" color="orange.700">
+                    Osittainen palautus: {selectedIds.size} / {inuseReservations.length} tavaraa
+                  </Text>
+                  <Text fontSize="sm" mt={1}>
+                    Valitsemattomat tavarat jäävät lainaan ja voit palauttaa ne myöhemmin.
+                  </Text>
+                </Box>
+              )}
 
               <Box p={6} bg={reportBg} borderRadius="lg" borderWidth="2px" borderColor={reportBorder}>
                 <Text fontSize="md" lineHeight="tall">
@@ -262,9 +321,9 @@ const LoanReturnCard = ({
 
               <Box p={6} bg={infoBg} borderRadius="lg" borderWidth="2px" borderColor="blue.200">
                 <Text fontSize="md" lineHeight="tall">
-                  Vahvistamalla palautuksen otat vastuun siitä, että kaikki tavarat ovat mukana,
-                  puhtaita ja toimivassa kunnossa sekä mahdolliset vahingot raportoituna. Palauta
-                  tavarat oikeaan laatikkoon.
+                  Vahvistamalla palautuksen otat vastuun siitä, että valitsemasi tavarat ovat
+                  mukana, puhtaita ja toimivassa kunnossa sekä mahdolliset vahingot raportoituna.
+                  Palauta tavarat oikeaan laatikkoon.
                 </Text>
 
                 <Checkbox
@@ -273,7 +332,9 @@ const LoanReturnCard = ({
                   isChecked={termsAccepted}
                   onChange={(e) => setTermsAccepted(e.target.checked)}
                 >
-                  Ymmärrän ja hyväksyn vastuuni palautettavista tavaroista.
+                  {allSelected
+                    ? 'Ymmärrän ja hyväksyn vastuuni palautettavista tavaroista.'
+                    : 'Ymmärrän että valitsemattomat tavarat jäävät yhä minun vastuulleni.'}
                 </Checkbox>
               </Box>
 
@@ -283,9 +344,11 @@ const LoanReturnCard = ({
                 onClick={handleConfirmReturn}
                 height="60px"
                 fontSize="xl"
-                isDisabled={!termsAccepted}
+                isDisabled={!termsAccepted || selectedIds.size === 0}
               >
-                Vahvista palautus
+                {isPartialReturn
+                  ? `Vahvista osittainen palautus (${selectedIds.size})`
+                  : 'Vahvista palautus'}
               </Button>
             </VStack>
           </ModalBody>
@@ -369,6 +432,7 @@ export default function KioskReturn({ loans }: { loans: LoanType[] }) {
 
   const handleReturn = async (
     loanId: string,
+    reservationIds: string[],
   ): Promise<{ name: string; description: string | null } | null> => {
     try {
       const response = await fetch('/api/loan/loanReturned', {
@@ -376,7 +440,7 @@ export default function KioskReturn({ loans }: { loans: LoanType[] }) {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ id: loanId }),
+        body: JSON.stringify({ id: loanId, reservationIds }),
       });
 
       if (response.ok) {

--- a/pages/loan/[id].tsx
+++ b/pages/loan/[id].tsx
@@ -36,7 +36,6 @@ import {
   Item,
   Box as BoxType,
   ReservationStatus,
-  LoanStatus,
 } from '@prisma/client';
 import {
   Checkbox,
@@ -184,7 +183,14 @@ export default function LoanView({
       });
   };
 
-  const [processingIds, setProcessingIds] = React.useState<Set<string>>(() => new Set());
+  const [processingIds, setProcessingIds] = React.useState<Set<string>>(
+    () =>
+      new Set(
+        loan.reservations
+          .filter((r) => r.status === ReservationStatus.IN_BOX)
+          .map((r) => r.id),
+      ),
+  );
 
   const loanProcessed = async () => {
     const reservationIds = Array.from(processingIds);
@@ -289,12 +295,6 @@ export default function LoanView({
     (r) => r.status === ReservationStatus.IN_BOX,
   );
   const canMarkReturned = isAdmin && inBoxReservations.length > 0;
-
-  // Sync the processing selection to the current IN_BOX set whenever it changes.
-  React.useEffect(() => {
-    setProcessingIds(new Set(inBoxReservations.map((r) => r.id)));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loan.id]);
   const canSeeReports = isAdmin && reports.length > 0;
 
   return (

--- a/pages/loan/[id].tsx
+++ b/pages/loan/[id].tsx
@@ -29,7 +29,20 @@ interface Report {
 import StartLoanConfirmation from '../../components/StartLoanConfirmation';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { useSession } from 'next-auth/react';
-import { Loan, User, Reservation, Item, Box as BoxType, ReservationStatus } from '@prisma/client';
+import {
+  Loan,
+  User,
+  Reservation,
+  Item,
+  Box as BoxType,
+  ReservationStatus,
+  LoanStatus,
+} from '@prisma/client';
+import {
+  Checkbox,
+  HStack,
+  VStack,
+} from '@chakra-ui/react';
 import { getLoanStatusLabel, getLoanStatusColor, deriveLoanStatus } from '../../utils/loanHelpers';
 
 import {
@@ -171,14 +184,26 @@ export default function LoanView({
       });
   };
 
+  const [processingIds, setProcessingIds] = React.useState<Set<string>>(() => new Set());
+
   const loanProcessed = async () => {
+    const reservationIds = Array.from(processingIds);
     await fetch('/api/loan/loanProcessed', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: loan.id }),
+      body: JSON.stringify({ id: loan.id, reservationIds }),
     });
     toast({ title: 'Kamat palautettu', status: 'success', duration: 5000, isClosable: true });
     router.push('/loan');
+  };
+
+  const toggleProcessing = (id: string) => {
+    setProcessingIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   };
 
   // Raporttien API-funktiot
@@ -242,22 +267,34 @@ export default function LoanView({
     (isAdmin || session?.user?.id === loan.user.id) &&
     derivedStatus !== 'REJECTED' &&
     derivedStatus !== 'INUSE' &&
+    derivedStatus !== 'PARTIALLY_RETURNED' &&
     derivedStatus !== 'RETURNED';
 
   const canEdit =
     (isAdmin || session?.user?.id === loan.user.id) &&
     derivedStatus !== 'INUSE' &&
+    derivedStatus !== 'PARTIALLY_RETURNED' &&
     derivedStatus !== 'RETURNED';
 
   const canApprove =
     isAdmin &&
     derivedStatus !== 'ACCEPTED' &&
     derivedStatus !== 'INUSE' &&
+    derivedStatus !== 'PARTIALLY_RETURNED' &&
     derivedStatus !== 'RETURNED';
 
   const canStartUse = derivedStatus === 'ACCEPTED';
 
-  const canMarkReturned = isAdmin && (derivedStatus === 'INUSE' || derivedStatus === 'IN_BOX');
+  const inBoxReservations = loan.reservations.filter(
+    (r) => r.status === ReservationStatus.IN_BOX,
+  );
+  const canMarkReturned = isAdmin && inBoxReservations.length > 0;
+
+  // Sync the processing selection to the current IN_BOX set whenever it changes.
+  React.useEffect(() => {
+    setProcessingIds(new Set(inBoxReservations.map((r) => r.id)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loan.id]);
   const canSeeReports = isAdmin && reports.length > 0;
 
   return (
@@ -356,10 +393,49 @@ export default function LoanView({
           <Box bg={cardBg} p={6} borderRadius="lg" borderWidth="1px">
             <Stack spacing={3}>
               <Heading as="h3" size="md" mb={2}>
-                Toiminnot
+                Merkitse laatikossa olevat palautetuksi
               </Heading>
-              <Button onClick={loanProcessed} colorScheme="green" size="lg" width="full">
-                Merkitse kamat palautetuksi
+              <Text fontSize="sm" color="gray.500">
+                Valitse ne tavarat, jotka olet fyysisesti tarkistanut laatikosta. Vielä käytössä
+                olevat tavarat (sininen tila) eivät näy tässä eivätkä ne muutu.
+              </Text>
+              <VStack align="stretch" spacing={2}>
+                {inBoxReservations.map((r) => (
+                  <HStack
+                    key={r.id}
+                    p={3}
+                    borderWidth="1px"
+                    borderRadius="md"
+                    borderColor={
+                      processingIds.has(r.id) ? 'green.400' : 'gray.200'
+                    }
+                    onClick={() => toggleProcessing(r.id)}
+                    cursor="pointer"
+                  >
+                    <Checkbox
+                      isChecked={processingIds.has(r.id)}
+                      onChange={() => toggleProcessing(r.id)}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                    <Text flex={1}>
+                      {r.item.name}{' '}
+                      <Text as="span" color="gray.500">
+                        ({r.amount} kpl)
+                      </Text>
+                    </Text>
+                  </HStack>
+                ))}
+              </VStack>
+              <Button
+                onClick={loanProcessed}
+                colorScheme="green"
+                size="lg"
+                width="full"
+                isDisabled={processingIds.size === 0}
+              >
+                {processingIds.size === inBoxReservations.length
+                  ? 'Merkitse kaikki laatikossa olevat palautetuksi'
+                  : `Merkitse valitut palautetuksi (${processingIds.size})`}
               </Button>
             </Stack>
           </Box>

--- a/pages/loan/index.tsx
+++ b/pages/loan/index.tsx
@@ -163,7 +163,12 @@ export default function LoanList() {
   const { data: loans, error, isLoading } = useSWR<LoanType[]>('/api/loan/getLoansClient');
   const allStatuses = Object.values(LoanStatus);
   const [selectedStatuses, setSelectedStatuses] = useState<Set<LoanStatus>>(
-    new Set([LoanStatus.ACCEPTED, LoanStatus.IN_BOX, LoanStatus.INUSE]),
+    new Set([
+      LoanStatus.ACCEPTED,
+      LoanStatus.IN_BOX,
+      LoanStatus.INUSE,
+      LoanStatus.PARTIALLY_RETURNED,
+    ]),
   );
 
   const allChecked = selectedStatuses.size === allStatuses.length;

--- a/prisma/migrations/20260413000000_add_partially_returned_loan_status/migration.sql
+++ b/prisma/migrations/20260413000000_add_partially_returned_loan_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "LoanStatus" ADD VALUE 'PARTIALLY_RETURNED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -179,6 +179,7 @@ enum LoanStatus {
   REJECTED
   INUSE
   IN_BOX
+  PARTIALLY_RETURNED
   RETURNED
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -59,7 +59,7 @@ export interface LoanCardProps {
     id: string;
     startTime: Date;
     endTime: Date;
-    status: 'ACCEPTED' | 'REJECTED' | 'INUSE' | 'IN_BOX' | 'RETURNED';
+    status: 'ACCEPTED' | 'REJECTED' | 'INUSE' | 'IN_BOX' | 'PARTIALLY_RETURNED' | 'RETURNED';
     description?: string;
     user: User;
     reservations: {

--- a/utils/loanHelpers.ts
+++ b/utils/loanHelpers.ts
@@ -10,6 +10,8 @@ export const getLoanStatusLabel = (status: LoanStatus): string => {
       return 'Käytössä';
     case LoanStatus.IN_BOX:
       return 'Laatikossa';
+    case LoanStatus.PARTIALLY_RETURNED:
+      return 'Osittain palautettu';
     case LoanStatus.RETURNED:
       return 'Palautettu';
     default:
@@ -27,6 +29,8 @@ export const getLoanStatusColor = (status: LoanStatus): string => {
       return 'blue';
     case LoanStatus.IN_BOX:
       return 'purple';
+    case LoanStatus.PARTIALLY_RETURNED:
+      return 'orange';
     case LoanStatus.RETURNED:
       return 'gray';
     default:
@@ -70,15 +74,14 @@ export const getReservationStatusColor = (status: ReservationStatus): string => 
 
 /**
  * Derives the overall loan status from its reservations.
- * Falls back to the loan's own DB status when reservations are
- * empty or don't match any specific condition.
  *
  * Priority order:
- * 1. If all reservations are RETURNED -> RETURNED
- * 2. If all reservations are REJECTED -> REJECTED
- * 3. If any reservation is IN_BOX -> IN_BOX
- * 4. If any reservation is INUSE -> INUSE
- * 5. Otherwise -> loan's DB status
+ * 1. All RETURNED -> RETURNED
+ * 2. All REJECTED -> REJECTED
+ * 3. Mix of INUSE + (IN_BOX or RETURNED) -> PARTIALLY_RETURNED
+ * 4. Any INUSE -> INUSE (remaining non-INUSE are ACCEPTED/REJECTED)
+ * 5. Any IN_BOX -> IN_BOX
+ * 6. Otherwise -> loan's DB status
  */
 export const deriveLoanStatus = (
   reservations: { status: ReservationStatus }[],
@@ -92,11 +95,19 @@ export const deriveLoanStatus = (
   if (reservations.every((r) => r.status === ReservationStatus.REJECTED)) {
     return LoanStatus.REJECTED;
   }
-  if (reservations.some((r) => r.status === ReservationStatus.IN_BOX)) {
-    return LoanStatus.IN_BOX;
+
+  const hasInuse = reservations.some((r) => r.status === ReservationStatus.INUSE);
+  const hasInBox = reservations.some((r) => r.status === ReservationStatus.IN_BOX);
+  const hasReturned = reservations.some((r) => r.status === ReservationStatus.RETURNED);
+
+  if (hasInuse && (hasInBox || hasReturned)) {
+    return LoanStatus.PARTIALLY_RETURNED;
   }
-  if (reservations.some((r) => r.status === ReservationStatus.INUSE)) {
+  if (hasInuse) {
     return LoanStatus.INUSE;
+  }
+  if (hasInBox) {
+    return LoanStatus.IN_BOX;
   }
 
   return loanStatus;


### PR DESCRIPTION
## Summary
- Users can now return a subset of a loan's items at the kiosk instead of having to return everything at once. The remaining items stay tracked against the loan so the audit trail isn't lost.
- Admins (kalustonhoitaja) get per-item controls on the loan detail page to mark specific IN_BOX items as RETURNED without touching items still out with the borrower.
- New `PARTIALLY_RETURNED` loan status (label "Osittain palautettu", orange) so the mixed state is visible everywhere the loan shows up.

## Caveats / things worth knowing
- **Box reuse:** if a loan is partially returned twice, the second batch is forced into the same physical box as the first (via `loan.boxId`). Box-selection heuristics only run the first time.
- **`loanProcessed` was quietly broken before this PR:** `updateMany where: {}` would have clobbered still-INUSE reservations once partial state existed. Now scoped to `status: IN_BOX`.
- **`editLoan` guard** was also tightened — it previously allowed editing `IN_BOX` loans, which is nonsense. Now blocked alongside `PARTIALLY_RETURNED`.
- **Crons untouched:** `checkOverdueLoans` / `checkExpiringLoans` key on reservation statuses directly, so partially returned loans with still-INUSE items will keep triggering overdue emails correctly. Worth sanity-checking if you disagree.
- **Damage reports** still attach to the whole loan, not specific reservations — a user partially returning twice with damages at both steps will file two reports on the same loan. Seems fine.

## Test plan
- [x] `vitest run __tests__/loan-status.test.ts` — 20/20 pass (5 new cases for PARTIALLY_RETURNED)
- [x] `tsc --noEmit` clean
- [ ] Migrate a dev DB, borrow 3 items as kiosk, return 1 → loan shows "Osittain palautettu" in kiosk list and loan list
- [ ] Partially return again, confirm box assignment matches the first partial return
- [ ] Admin marks one IN_BOX item returned, confirm INUSE items untouched and boxId cleared only when no IN_BOX remain
- [ ] Admin marks all IN_BOX items returned on a fully-returned-to-box loan → loan becomes RETURNED, boxId cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)