### PR TITLE
feat: advise users to photograph items

### DIFF
--- a/pages/kiosk/return.tsx
+++ b/pages/kiosk/return.tsx
@@ -242,6 +242,19 @@ const LoanReturnCard = ({
                 osan nyt ja loput myöhemmin.
               </Text>
 
+              <Box p={4} bg="blue.50" borderRadius="lg" borderWidth="2px" borderColor="blue.300">
+                <Text fontSize="md" fontWeight="bold" color="blue.800">
+                  💡 Vinkki: Ota kuva palautettavista kamoista
+                </Text>
+                <Text fontSize="sm" mt={1} color="blue.900">
+                  Suosittelemme ottamaan kuvan palautettavista tavaroista puhelimellasi ennen kuin
+                  laitat ne laatikkoon. Jos palautuksesta tulee myöhemmin hämminkiä (esim. joku
+                  väittää, ettei tavaraa palautettu, tai jokin on vioittunut), kuva puhelimessasi
+                  toimii omana todisteenasi. Kuvaa ei tarvitse lähettää mihinkään — säilytä se
+                  omassa puhelimessasi.
+                </Text>
+              </Box>
+
               <VStack spacing={4} align="stretch">
                 {inuseReservations.map((reservation) => {
                   const checked = selectedIds.has(reservation.id);

--- a/pages/kiosk/startloan.tsx
+++ b/pages/kiosk/startloan.tsx
@@ -171,6 +171,24 @@ const LoanStartCard = ({
             <Box
               mb={4}
               p={3}
+              bg="blue.50"
+              borderRadius="md"
+              borderWidth="1px"
+              borderColor="blue.300"
+            >
+              <Text fontSize="md" lineHeight="tall" fontWeight="bold" color="blue.800">
+                💡 Vinkki: Ota kuva kamoista puhelimellasi
+              </Text>
+              <Text fontSize="md" lineHeight="tall" mt={1} color="blue.900">
+                Suosittelemme ottamaan kuvan kamoista ennen lainauksen aloitusta. Jos palautuksessa
+                tulee hämminkiä (puuttuuko jotain, oliko jokin rikki jo etukäteen), kuva puhelimessasi
+                toimii omana todisteenasi. Kuvaa ei tarvitse lähettää mihinkään — säilytä se omassa
+                puhelimessasi.
+              </Text>
+            </Box>
+            <Box
+              mb={4}
+              p={3}
               bg={itemBg}
               borderRadius="md"
               borderWidth="1px"


### PR DESCRIPTION
## Summary
Add a Finnish tip in both the kiosk **start-loan** and **return** modals encouraging users to snap a phone photo of the items for their own protection. If a dispute comes up later ("tavara puuttuu", "tää oli jo rikki etukäteen"), the photo on the user's own phone is their personal evidence.

**No upload feature** — the tip explicitly tells users to keep the photo on their own device. No storage, no API changes, no schema changes, just some reassuring copy.

## Copy (for review)

Start-loan modal:
> 💡 Vinkki: Ota kuva kamoista puhelimellasi
>
> Suosittelemme ottamaan kuvan kamoista ennen lainauksen aloitusta. Jos palautuksessa tulee hämminkiä (puuttuuko jotain, oliko jokin rikki jo etukäteen), kuva puhelimessasi toimii omana todisteenasi. Kuvaa ei tarvitse lähettää mihinkään — säilytä se omassa puhelimessasi.

Return modal:
> 💡 Vinkki: Ota kuva palautettavista kamoista
>
> Suosittelemme ottamaan kuvan palautettavista tavaroista puhelimellasi ennen kuin laitat ne laatikkoon. Jos palautuksesta tulee myöhemmin hämminkiä (esim. joku väittää, ettei tavaraa palautettu, tai jokin on vioittunut), kuva puhelimessasi toimii omana todisteenasi. Kuvaa ei tarvitse lähettää mihinkään — säilytä se omassa puhelimessasi.

## Test plan
- [ ] Open kiosk start-loan flow, confirm the blue tip box appears above the damage-report section
- [ ] Open kiosk return flow, confirm the blue tip box appears below the heading and above the item checkboxes
- [ ] Sanity check the copy reads naturally in Finnish

🤖 Generated with [Claude Code](https://claude.com/claude-code)