### PR TITLE
feat: add loan history audit log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# claude
+.claude
+
 # lock files
 yarn.lock
 package-lock.json

--- a/pages/api/loan/approveLoan.ts
+++ b/pages/api/loan/approveLoan.ts
@@ -3,6 +3,7 @@ import prisma from '../../../utils/prisma';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logLoanHistory } from '../../../utils/loanHistory';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
@@ -29,6 +30,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         },
       },
     },
+  });
+  await logLoanHistory({
+    loanId: id,
+    action: 'APPROVED',
+    actedById: session.user.id,
   });
   res.status(200).json(result);
 }

--- a/pages/api/loan/loanProcessed.ts
+++ b/pages/api/loan/loanProcessed.ts
@@ -4,6 +4,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { deriveLoanStatus } from '../../../utils/loanHelpers';
+import { logLoanHistory } from '../../../utils/loanHistory';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
@@ -63,6 +64,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           data: { status: ReservationStatus.RETURNED },
         },
       },
+    },
+  });
+
+  await logLoanHistory({
+    loanId: id,
+    action: 'PROCESSED_FROM_BOX',
+    actedById: session.user.id,
+    details: {
+      reservationIds: targetIds,
+      count: targetIds.length,
+      newStatus: newLoanStatus,
     },
   });
 

--- a/pages/api/loan/loanReturned.ts
+++ b/pages/api/loan/loanReturned.ts
@@ -4,6 +4,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { deriveLoanStatus } from '../../../utils/loanHelpers';
+import { logLoanHistory } from '../../../utils/loanHistory';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
@@ -131,6 +132,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     },
     include: {
       box: true,
+    },
+  });
+
+  const returnedItems = loan.reservations
+    .filter((r) => targetIds.includes(r.id))
+    .map((r) => r.id);
+  await logLoanHistory({
+    loanId: id,
+    action: 'RETURNED_TO_BOX',
+    actedById: session.user.id,
+    details: {
+      boxId: selectedBox.id,
+      boxName: selectedBox.name,
+      reservationIds: returnedItems,
+      count: returnedItems.length,
+      newStatus: newLoanStatus,
     },
   });
 

--- a/pages/api/loan/rejectLoan.ts
+++ b/pages/api/loan/rejectLoan.ts
@@ -3,6 +3,7 @@ import prisma from '../../../utils/prisma';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logLoanHistory } from '../../../utils/loanHistory';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
@@ -29,6 +30,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         },
       },
     },
+  });
+  await logLoanHistory({
+    loanId: id,
+    action: 'REJECTED',
+    actedById: session.user.id,
   });
   res.status(200).json(result);
 }

--- a/pages/api/loan/startLoan.ts
+++ b/pages/api/loan/startLoan.ts
@@ -3,6 +3,7 @@ import prisma from '../../../utils/prisma';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logLoanHistory } from '../../../utils/loanHistory';
 
 // Converts an approved loan to in-use status
 // Can be called by:
@@ -67,6 +68,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         },
       },
     },
+  });
+
+  await logLoanHistory({
+    loanId: id,
+    action: 'STARTED',
+    actedById: session.user.id,
   });
 
   res.status(200).json(result);

--- a/pages/api/loan/submitLoan.ts
+++ b/pages/api/loan/submitLoan.ts
@@ -5,6 +5,7 @@ import { authOptions } from '../auth/[...nextauth]';
 import { ReservationStatus } from '@prisma/client';
 import 'dotenv/config';
 import { getBaseUrl } from '../../../utils/urlHelpers';
+import { logLoanHistory } from '../../../utils/loanHistory';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -98,6 +99,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         description,
         loaner,
         status: loanStatus,
+      },
+    });
+
+    await logLoanHistory({
+      loanId: result.id,
+      action: 'CREATED',
+      actedById: session.user.id,
+      details: {
+        status: loanStatus,
+        itemCount: createReservations.length,
+        loaner: loaner ?? null,
+        description: description ?? null,
       },
     });
 

--- a/pages/api/loan/updateLoan.ts
+++ b/pages/api/loan/updateLoan.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]';
 import { ReservationStatus } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logLoanHistory } from '../../../utils/loanHistory';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -165,6 +166,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         startTime: startTime,
         endTime: endTime,
         description: description,
+      },
+    });
+
+    await logLoanHistory({
+      loanId: id,
+      action: 'UPDATED',
+      actedById: session.user.id,
+      details: {
+        startTime,
+        endTime,
+        description: description ?? null,
+        itemCount: reservationsWithStatus.length,
       },
     });
 

--- a/pages/loan/[id].tsx
+++ b/pages/loan/[id].tsx
@@ -43,6 +43,8 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import { getLoanStatusLabel, getLoanStatusColor, deriveLoanStatus } from '../../utils/loanHelpers';
+import { getLoanHistoryActionLabel } from '../../utils/loanHistory';
+import { LoanHistoryAction } from '@prisma/client';
 
 import {
   Modal,
@@ -63,12 +65,26 @@ interface LoanWithRelations extends Loan {
   })[];
 }
 
+interface HistoryEntry {
+  id: string;
+  action: LoanHistoryAction;
+  createdAt: string | Date;
+  details: unknown;
+  actedBy: { id: string; name: string | null; email: string | null } | null;
+}
+
 import { serialize } from '@/utils/serialize';
 import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 
 export async function getServerSideProps(
   req: GetServerSidePropsContext,
-): Promise<GetServerSidePropsResult<{ loan: LoanWithRelations; reports: Report[] }>> {
+): Promise<
+  GetServerSidePropsResult<{
+    loan: LoanWithRelations;
+    reports: Report[];
+    history: HistoryEntry[];
+  }>
+> {
   if (!req.params?.id || typeof req.params.id !== 'string') {
     return { notFound: true };
   }
@@ -100,6 +116,14 @@ export async function getServerSideProps(
     },
   });
 
+  const history = await prisma.loanHistory.findMany({
+    where: { loanId: req.params.id },
+    orderBy: { createdAt: 'desc' },
+    include: {
+      actedBy: { select: { id: true, name: true, email: true } },
+    },
+  });
+
   if (!loan) {
     return { notFound: true };
   }
@@ -108,6 +132,7 @@ export async function getServerSideProps(
     props: serialize({
       loan,
       reports,
+      history,
     }),
   };
 }
@@ -115,9 +140,11 @@ export async function getServerSideProps(
 export default function LoanView({
   loan,
   reports,
+  history,
 }: {
   loan: LoanWithRelations;
   reports: Report[];
+  history: HistoryEntry[];
 }) {
   const router = useRouter();
   const toast = useToast();
@@ -474,6 +501,49 @@ export default function LoanView({
             </Box>
           )
         )}
+
+        <Box bg={cardBg} p={6} borderRadius="lg" borderWidth="1px">
+          <Heading as="h2" size="lg" mb={4}>
+            Historia
+          </Heading>
+          {history.length === 0 ? (
+            <Text color="gray.500">Ei historiamerkintöjä.</Text>
+          ) : (
+            <VStack align="stretch" spacing={3}>
+              {history.map((entry) => {
+                const who =
+                  entry.actedBy?.name ||
+                  entry.actedBy?.email ||
+                  'Järjestelmä';
+                const when = new Date(entry.createdAt).toLocaleString('fi-FI', {
+                  dateStyle: 'short',
+                  timeStyle: 'short',
+                });
+                return (
+                  <Box
+                    key={entry.id}
+                    p={3}
+                    borderWidth="1px"
+                    borderRadius="md"
+                    borderColor="gray.200"
+                  >
+                    <HStack justify="space-between" align="start" flexWrap="wrap">
+                      <Text fontWeight="semibold">
+                        {getLoanHistoryActionLabel(entry.action)}
+                      </Text>
+                      <Text fontSize="sm" color="gray.500">
+                        {when}
+                      </Text>
+                    </HStack>
+                    <Text fontSize="sm" color="gray.600">
+                      {who}
+                    </Text>
+                  </Box>
+                );
+              })}
+            </VStack>
+          )}
+        </Box>
 
         <Modal isOpen={isOpen} onClose={onClose}>
           <ModalOverlay />

--- a/prisma/migrations/20260415000000_add_loan_history/migration.sql
+++ b/prisma/migrations/20260415000000_add_loan_history/migration.sql
@@ -1,0 +1,23 @@
+-- CreateEnum
+CREATE TYPE "LoanHistoryAction" AS ENUM ('CREATED', 'UPDATED', 'APPROVED', 'REJECTED', 'STARTED', 'RETURNED_TO_BOX', 'PROCESSED_FROM_BOX');
+
+-- CreateTable
+CREATE TABLE "LoanHistory" (
+    "id" TEXT NOT NULL,
+    "loanId" TEXT NOT NULL,
+    "action" "LoanHistoryAction" NOT NULL,
+    "details" JSONB,
+    "actedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LoanHistory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "LoanHistory_loanId_createdAt_idx" ON "LoanHistory"("loanId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "LoanHistory" ADD CONSTRAINT "LoanHistory_loanId_fkey" FOREIGN KEY ("loanId") REFERENCES "Loan"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LoanHistory" ADD CONSTRAINT "LoanHistory_actedById_fkey" FOREIGN KEY ("actedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,24 +38,25 @@ model Session {
 }
 
 model User {
-  id                       String     @id @default(cuid())
+  id                       String         @id @default(cuid())
   name                     String?
-  email                    String?    @unique
+  email                    String?        @unique
   emailVerified            DateTime?
   image                    String?
-  group                    Group      @default(USER)
+  group                    Group          @default(USER)
   password                 String?
   passwordExpiresAt        DateTime?
   kioskElevatePin          String?
-  username                 String?    @unique
-  emailNewLoanNotification Boolean    @default(true)
-  emailWeeklyReminder      Boolean    @default(true)
-  emailOldBoxNotification  Boolean    @default(true)
-  emailOverdueNotification Boolean    @default(true)
+  username                 String?        @unique
+  emailNewLoanNotification Boolean        @default(true)
+  emailWeeklyReminder      Boolean        @default(true)
+  emailOldBoxNotification  Boolean        @default(true)
+  emailOverdueNotification Boolean        @default(true)
   accounts                 Account[]
   loans                    Loan[]
   sessions                 Session[]
   emailLogs                EmailLog[]
+  loanHistoryEntries       LoanHistory[]
 }
 
 model Item {
@@ -128,6 +129,30 @@ model Loan {
   reservations Reservation[]
   reports      Report[]
   emailLogs    EmailLog[]
+  history      LoanHistory[]
+}
+
+model LoanHistory {
+  id        String            @id @default(cuid())
+  loanId    String
+  action    LoanHistoryAction
+  details   Json?
+  actedById String?
+  createdAt DateTime          @default(now())
+  loan      Loan              @relation(fields: [loanId], references: [id], onDelete: Cascade)
+  actedBy   User?             @relation(fields: [actedById], references: [id], onDelete: SetNull)
+
+  @@index([loanId, createdAt])
+}
+
+enum LoanHistoryAction {
+  CREATED
+  UPDATED
+  APPROVED
+  REJECTED
+  STARTED
+  RETURNED_TO_BOX
+  PROCESSED_FROM_BOX
 }
 
 model Report {

--- a/utils/loanHistory.ts
+++ b/utils/loanHistory.ts
@@ -1,0 +1,43 @@
+import { LoanHistoryAction, Prisma } from '@prisma/client';
+import prisma from './prisma';
+
+export async function logLoanHistory(params: {
+  loanId: string;
+  action: LoanHistoryAction;
+  actedById?: string | null;
+  details?: Prisma.InputJsonValue;
+}): Promise<void> {
+  try {
+    await prisma.loanHistory.create({
+      data: {
+        loanId: params.loanId,
+        action: params.action,
+        actedById: params.actedById ?? null,
+        details: params.details ?? Prisma.JsonNull,
+      },
+    });
+  } catch (err) {
+    console.error('Failed to log loan history:', err);
+  }
+}
+
+export function getLoanHistoryActionLabel(action: LoanHistoryAction): string {
+  switch (action) {
+    case 'CREATED':
+      return 'Laina luotu';
+    case 'UPDATED':
+      return 'Lainaa muokattu';
+    case 'APPROVED':
+      return 'Laina hyväksytty';
+    case 'REJECTED':
+      return 'Laina hylätty';
+    case 'STARTED':
+      return 'Lainaus aloitettu';
+    case 'RETURNED_TO_BOX':
+      return 'Kamat palautettu laatikkoon';
+    case 'PROCESSED_FROM_BOX':
+      return 'Kamat merkitty palautetuksi';
+    default:
+      return action;
+  }
+}


### PR DESCRIPTION
## Summary
- New `LoanHistory` table (append-only) records every loan mutation with timestamp, actor, and action-specific details.
- All seven loan mutation endpoints (`submitLoan`, `updateLoan`, `approveLoan`, `rejectLoan`, `startLoan`, `loanReturned`, `loanProcessed`) log via a shared `logLoanHistory` helper that swallows errors so audit failures never break the mutation.
- Loan detail page fetches and renders the history as a "Historia" card (newest first, actor + timestamp).

## Test plan
- [ ] `pnpm prisma migrate deploy` applies `20260415000000_add_loan_history`
- [ ] Create, edit, approve, start, return, and process a loan — each action appears in the history card
- [ ] History entry shows the acting user and a localized timestamp
- [ ] Deleting the acting user preserves the entry (actedBy becomes null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)