### PR TITLE
fix: resolve pg/tls client bundle error from loan history

### DIFF
--- a/pages/loan/[id].tsx
+++ b/pages/loan/[id].tsx
@@ -42,8 +42,12 @@ import {
   HStack,
   VStack,
 } from '@chakra-ui/react';
-import { getLoanStatusLabel, getLoanStatusColor, deriveLoanStatus } from '../../utils/loanHelpers';
-import { getLoanHistoryActionLabel } from '../../utils/loanHistory';
+import {
+  getLoanStatusLabel,
+  getLoanStatusColor,
+  deriveLoanStatus,
+  getLoanHistoryActionLabel,
+} from '../../utils/loanHelpers';
 import { LoanHistoryAction } from '@prisma/client';
 
 import {

--- a/utils/loanHelpers.ts
+++ b/utils/loanHelpers.ts
@@ -1,4 +1,25 @@
-import { LoanStatus, ReservationStatus } from '@prisma/client';
+import { LoanStatus, ReservationStatus, LoanHistoryAction } from '@prisma/client';
+
+export const getLoanHistoryActionLabel = (action: LoanHistoryAction): string => {
+  switch (action) {
+    case 'CREATED':
+      return 'Laina luotu';
+    case 'UPDATED':
+      return 'Lainaa muokattu';
+    case 'APPROVED':
+      return 'Laina hyväksytty';
+    case 'REJECTED':
+      return 'Laina hylätty';
+    case 'STARTED':
+      return 'Lainaus aloitettu';
+    case 'RETURNED_TO_BOX':
+      return 'Kamat palautettu laatikkoon';
+    case 'PROCESSED_FROM_BOX':
+      return 'Kamat merkitty palautetuksi';
+    default:
+      return action;
+  }
+};
 
 export const getLoanStatusLabel = (status: LoanStatus): string => {
   switch (status) {

--- a/utils/loanHistory.ts
+++ b/utils/loanHistory.ts
@@ -20,24 +20,3 @@ export async function logLoanHistory(params: {
     console.error('Failed to log loan history:', err);
   }
 }
-
-export function getLoanHistoryActionLabel(action: LoanHistoryAction): string {
-  switch (action) {
-    case 'CREATED':
-      return 'Laina luotu';
-    case 'UPDATED':
-      return 'Lainaa muokattu';
-    case 'APPROVED':
-      return 'Laina hyväksytty';
-    case 'REJECTED':
-      return 'Laina hylätty';
-    case 'STARTED':
-      return 'Lainaus aloitettu';
-    case 'RETURNED_TO_BOX':
-      return 'Kamat palautettu laatikkoon';
-    case 'PROCESSED_FROM_BOX':
-      return 'Kamat merkitty palautetuksi';
-    default:
-      return action;
-  }
-}


### PR DESCRIPTION
## Summary
- The loan detail page imported \`getLoanHistoryActionLabel\` from \`utils/loanHistory\`, which also statically imports the Prisma client (pulling \`pg\` → \`tls\`) into the page's client bundle — causing \`Module not found: Can't resolve 'tls'\` on deploy.
- Moved the label function into \`utils/loanHelpers\` (client-safe alongside the other status label helpers). \`logLoanHistory\` stays in \`utils/loanHistory\` and remains server-only.

## Test plan
- [ ] \`pnpm build\` succeeds locally
- [ ] Vercel preview deploy builds without the \`tls\` error
- [ ] Loan detail page still renders the Historia card with the correct Finnish labels