### PR TITLE
Sticky search/category bar and denser item grid

### DIFF
--- a/components/ItemBrowser.tsx
+++ b/components/ItemBrowser.tsx
@@ -45,13 +45,13 @@ export default function ItemBrowser({
 
   return (
     <>
-      <div className="p-1">
-        <div className="relative mb-4 w-fit">
+      <div className="sticky top-16 z-30 -mx-4 flex flex-col gap-2 border-b bg-background/95 px-4 pb-3 pt-2 backdrop-blur-xs">
+        <div className="relative w-full sm:w-fit">
           <Input
             placeholder="Hae kamoja"
             value={search}
             onChange={handleChange}
-            className="pr-9"
+            className="h-9 pr-9"
           />
           <div className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground">
             {search ? (
@@ -66,74 +66,78 @@ export default function ItemBrowser({
             )}
           </div>
         </div>
-      </div>
-      <div className="hidden py-8 pl-0 md:block">
-        <div className="flex flex-wrap gap-2 p-1">
-          <Button
-            key="all"
-            onClick={() => setCategory('')}
-            variant={category === '' ? 'default' : 'outline-solid'}
-          >
-            Kaikki
-          </Button>
-          {[...categories]
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map((cat) => (
-              <Button
-                key={cat.id}
-                onClick={() => setCategory(category === cat.name ? '' : cat.name)}
-                variant={category === cat.name ? 'default' : 'outline-solid'}
-              >
-                {cat.name}
-              </Button>
-            ))}
+        <div className="hidden md:block">
+          <div className="flex flex-wrap gap-1.5">
+            <Button
+              key="all"
+              size="xs"
+              onClick={() => setCategory('')}
+              variant={category === '' ? 'default' : 'outline-solid'}
+            >
+              Kaikki
+            </Button>
+            {[...categories]
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((cat) => (
+                <Button
+                  key={cat.id}
+                  size="xs"
+                  onClick={() => setCategory(category === cat.name ? '' : cat.name)}
+                  variant={category === cat.name ? 'default' : 'outline-solid'}
+                >
+                  {cat.name}
+                </Button>
+              ))}
+          </div>
         </div>
-      </div>
-      <div className="py-8 pl-0 md:hidden">
-        <select
-          className={cn(
-            'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-          )}
-          value={category}
-          onChange={(e) => setCategory(e.target.value)}
-        >
-          <option value="">Kaikki</option>
-          {[...categories]
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map((cat) => (
-              <option key={cat.id} value={cat.name}>
-                {cat.name}
-              </option>
-            ))}
-        </select>
-      </div>
-      {showCustomItemLink && (
-        <>
-          <div className="mb-4 flex items-center gap-3 rounded-md border-l-4 border-primary bg-primary/10 p-4">
-            <FaInfoCircle className="h-5 w-5 text-primary" />
+        <div className="md:hidden">
+          <select
+            className={cn(
+              'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            )}
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            <option value="">Kaikki</option>
+            {[...categories]
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((cat) => (
+                <option key={cat.id} value={cat.name}>
+                  {cat.name}
+                </option>
+              ))}
+          </select>
+        </div>
+        {showCustomItemLink && (
+          <div className="flex items-center gap-3 rounded-md border-l-4 border-primary bg-primary/10 px-3 py-2">
+            <FaInfoCircle className="h-4 w-4 shrink-0 text-primary" />
             <p className="text-sm">
               Jos haluamaasi kamaa ei löydy,{' '}
               <button
                 type="button"
-                className="font-semibold text-primary underline hover:text-primary/80"
+                className="cursor-pointer font-semibold text-primary underline hover:text-primary/80"
                 onClick={() => setDialogOpen(true)}
               >
                 klikkaa tästä
               </button>
             </p>
           </div>
-          <CustomItemDialog isOpen={dialogOpen} onClose={() => setDialogOpen(false)} />
-        </>
+        )}
+      </div>
+      {showCustomItemLink && (
+        <CustomItemDialog isOpen={dialogOpen} onClose={() => setDialogOpen(false)} />
       )}
-      {filteredItems.length > 0 ? (
-        renderItems ? (
-          renderItems(filteredItems)
+      <div className="pt-4">
+        {filteredItems.length > 0 ? (
+          renderItems ? (
+            renderItems(filteredItems)
+          ) : (
+            <AllItems items={filteredItems} categories={categories} />
+          )
         ) : (
-          <AllItems items={filteredItems} categories={categories} />
-        )
-      ) : (
-        <h2 className="mt-4 text-center text-2xl font-semibold">Ei hakutuloksia :(</h2>
-      )}
+          <h2 className="mt-4 text-center text-2xl font-semibold">Ei hakutuloksia :(</h2>
+        )}
+      </div>
     </>
   );
 }

--- a/components/ItemCard.tsx
+++ b/components/ItemCard.tsx
@@ -45,26 +45,26 @@ const ItemCard = memo(function ItemCard({ item, availableAmount }: ItemCardProps
 
   const action =
     amountInCart > 0 ? (
-      <div className="flex h-11 sm:mt-4 sm:h-14">
+      <div className="flex h-11 sm:mt-3 sm:h-11">
         <Button
           variant="outline"
           aria-label="decrement"
           onClick={handleDecrement}
-          className="h-full w-12 shrink-0 rounded-r-none text-lg sm:w-16 sm:text-xl"
+          className="h-full w-12 shrink-0 rounded-r-none text-lg sm:w-14 sm:text-lg"
         >
           <FaMinus />
         </Button>
         <Input
           value={amountInCart}
           readOnly
-          className="pointer-events-none h-full min-w-0 select-none rounded-none border-x-0 px-1 text-center text-base font-bold sm:text-lg"
+          className="pointer-events-none h-full min-w-0 select-none rounded-none border-x-0 px-1 text-center text-base font-bold sm:text-base"
         />
         <Button
           variant="outline"
           aria-label="increment"
           onClick={handleIncrement}
           disabled={!canTakeMoreItems}
-          className="h-full w-12 shrink-0 rounded-l-none text-lg sm:w-16 sm:text-xl"
+          className="h-full w-12 shrink-0 rounded-l-none text-lg sm:w-14 sm:text-lg"
         >
           <FaPlus />
         </Button>
@@ -72,7 +72,7 @@ const ItemCard = memo(function ItemCard({ item, availableAmount }: ItemCardProps
     ) : (
       <Button
         onClick={handleAddToCart}
-        className="h-11 w-full gap-2 text-base sm:mt-4 sm:h-14 sm:text-lg"
+        className="h-11 w-full gap-2 text-base sm:mt-3 sm:h-11 sm:text-base"
         disabled={!canTakeMoreItems}
       >
         {canTakeMoreItems ? 'Lisää' : 'Ei saatavilla'}

--- a/components/ItemCardShell.tsx
+++ b/components/ItemCardShell.tsx
@@ -57,22 +57,22 @@ export default function ItemCardShell({
         />
       </div>
 
-      <div className="flex min-w-0 flex-1 flex-col p-3 sm:p-5">
+      <div className="flex min-w-0 flex-1 flex-col p-3 sm:p-4 xl:p-3">
         <p
-          className="truncate text-base font-semibold leading-tight sm:text-2xl"
+          className="truncate text-base font-semibold leading-tight sm:text-lg xl:text-base"
           title={name}
         >
           {name}
         </p>
 
-        <div className="text-sm font-semibold sm:mt-1 sm:text-base">{subtitle}</div>
+        <div className="text-sm font-semibold sm:mt-0.5 sm:text-sm">{subtitle}</div>
 
         {categoryLine !== undefined && (
-          <p className="truncate text-xs text-muted-foreground sm:text-sm">{categoryLine}</p>
+          <p className="truncate text-xs text-muted-foreground sm:text-xs">{categoryLine}</p>
         )}
 
         {Array.isArray(announcements) && announcements.length > 0 && (
-          <div className="mt-1 flex items-center gap-1 text-xs font-semibold text-destructive sm:text-sm">
+          <div className="mt-1 flex items-center gap-1 text-xs font-semibold text-destructive">
             <LuTriangleAlert className="shrink-0" />
             <span className="truncate">Sisältää ilmoituksen</span>
           </div>

--- a/components/ItemGrid.tsx
+++ b/components/ItemGrid.tsx
@@ -60,7 +60,7 @@ export default function ItemGrid({ items }: ItemGridProps) {
   }
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 md:gap-6 lg:grid-cols-3 lg:gap-8 xl:grid-cols-4 xl:gap-10">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4 lg:gap-4 xl:grid-cols-5 2xl:grid-cols-6">
       {items.map((item) => (
         <ItemCard
           key={item.id}

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -164,7 +164,7 @@ export default function TopBar({ children }: { children: ReactNode }) {
       onClick={() => {
         handleBrowseClick();
       }}
-      className="font-medium text-white hover:underline"
+      className="cursor-pointer font-medium text-white hover:underline"
     >
       Kamat
     </button>
@@ -313,7 +313,7 @@ export default function TopBar({ children }: { children: ReactNode }) {
                 handleBrowseClick();
                 onClose();
               }}
-              className="px-6 py-4 text-left"
+              className="cursor-pointer px-6 py-4 text-left"
             >
               Kamat
             </button>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- Search, category selector and the "custom item" hint now stick under the TopBar while browsing items, with the category bar compacted (smaller buttons, less vertical padding) so it doesn't dominate the viewport when stuck.
- Item grid now goes to 5 columns at `xl` and 6 at `2xl`. Card internals (padding, title/subtitle sizes, +/- and "Lisää" button heights) are scaled down so the denser cards still look balanced.
- Added `cursor-pointer` to the base `Button` variant — Tailwind v4's preflight no longer sets it, so every button in the app (cart icon included) was missing the hand cursor on hover. A couple of raw `<button>` elements in `TopBar` and `ItemBrowser` got the same treatment.

## Test plan
- [x] Desktop: open `/` with dates selected, confirm 5 cols at ~1280–1535px and 6 cols at ≥1536px
- [x] Scroll the item list — search, categories and "jos kamaa ei löydy" stay pinned below the TopBar
- [x] Hover the cart icon and other buttons → pointer cursor
- [x] Mobile: category `<select>` still works, sticky region doesn't eat too much screen
- [x] Dark mode: sticky bar background is readable (uses `bg-background/95 backdrop-blur-xs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)