### PR TITLE
fix: focus description field when cart opens

### DIFF
--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -147,6 +147,10 @@ export default function CartDrawer({ isOpen, onClose }: { isOpen: boolean; onClo
       <DrawerContent
         side="right"
         className="flex max-h-dvh w-full flex-col md:max-w-md"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          firstField.current?.focus();
+        }}
         onPointerDownOutside={(e) => {
           // Prevent Radix from auto-closing when the cart button is clicked,
           // so the button's onClick toggle works without a race condition.


### PR DESCRIPTION
## Summary
- Override Radix's default auto-focus on the cart drawer so the description input receives focus on open instead of the loaner field.

## Test plan
- [ ] Open the cart — cursor lands in the "Kuvaus" field.
- [ ] As admin/kiosk, the loaner autocomplete still works when clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)