### PR TITLE
fix: start date picker week on Monday

### DIFF
--- a/components/DateSelector.tsx
+++ b/components/DateSelector.tsx
@@ -60,6 +60,7 @@ export default function DateSelector() {
                 inline
                 minDate={new Date()}
                 dateFormat="dd.MM.yyyy"
+                calendarStartDay={1}
               />
             </div>
             <Button
@@ -118,6 +119,7 @@ export default function DateSelector() {
                     inline
                     minDate={new Date()}
                     dateFormat="dd.MM.yyyy"
+                    calendarStartDay={1}
                   />
                 </div>
                 <Button

--- a/components/KioskDateSelector.tsx
+++ b/components/KioskDateSelector.tsx
@@ -65,6 +65,7 @@ export default function KioskDateSelector() {
               inline
               minDate={new Date()}
               dateFormat="dd.MM.yyyy"
+              calendarStartDay={1}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Set \`calendarStartDay={1}\` on the react-datepicker instances in \`DateSelector\` and \`KioskDateSelector\` so the calendar grid starts on Monday (FI convention) instead of Sunday.

## Test plan
- [ ] Open the booking flow and confirm the range picker shows Monday as the first column.
- [ ] Open the kiosk return-date picker and confirm the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)