### PR TITLE
Move 'Uusi kama' to Kamat view, rename Varaukset → Lainat

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React from 'react';
+import NextLink from 'next/link';
+import { FaPlus } from 'react-icons/fa';
 import DateSelector from '@/components/DateSelector';
 import KioskModeSelector from '@/components/KioskModeSelector';
 import KioskDateSelector from '@/components/KioskDateSelector';
@@ -11,17 +13,30 @@ import ItemBrowser from '@/components/ItemBrowser';
 import BrowseItemCard from '@/components/BrowseItemCard';
 import { Button } from '@/components/ui/button';
 
-function BrowseModeHeader({ onExitBrowseMode }: { onExitBrowseMode: () => void }) {
+function BrowseModeHeader({
+  onExitBrowseMode,
+  isAdmin,
+}: {
+  onExitBrowseMode: () => void;
+  isAdmin: boolean;
+}) {
   return (
     <div className="mb-4 flex flex-col gap-4">
       <div>
         <h2 className="mb-2 text-2xl font-semibold">Selaa katalogia</h2>
         <p className="text-muted-foreground">
-          Selaat katalogia ilman varaustoimintoa. Voit tarkastella saatavilla olevia kamoja.
+          Selaat katalogia ilman lainatoimintoa. Voit tarkastella saatavilla olevia kamoja.
         </p>
       </div>
-      <div>
-        <Button onClick={onExitBrowseMode}>Siirry varaamaan</Button>
+      <div className="flex flex-wrap gap-3">
+        <Button onClick={onExitBrowseMode}>Siirry lainaamaan</Button>
+        {isAdmin && (
+          <Button asChild variant="success" className="gap-2">
+            <NextLink href="/admin/createItem">
+              <FaPlus /> Luo uusi kama
+            </NextLink>
+          </Button>
+        )}
       </div>
     </div>
   );
@@ -44,6 +59,7 @@ export default function HomeClient({ items, categories }: HomeClientProps) {
   const { data: session } = useSession();
 
   const isKioskMode = session?.user?.group === 'KIOSK';
+  const isAdmin = session?.user?.group === 'ADMIN';
 
   const handleExitBrowseMode = () => {
     setBrowseMode(false);
@@ -69,7 +85,7 @@ export default function HomeClient({ items, categories }: HomeClientProps) {
     <>
       {dates.browseMode ? (
         <>
-          <BrowseModeHeader onExitBrowseMode={handleExitBrowseMode} />
+          <BrowseModeHeader onExitBrowseMode={handleExitBrowseMode} isAdmin={isAdmin} />
           <ItemBrowser
             items={filteredItems}
             categories={categories}

--- a/app/account/AccountView.tsx
+++ b/app/account/AccountView.tsx
@@ -188,22 +188,22 @@ export default function AccountView({ loans, userEmailPreferences }: AccountView
             {session?.user?.group === 'ADMIN' ? (
               <>
                 <PrefRow
-                  title="Uudet varaukset"
-                  description="Ilmoitukset uusista varauksista (myös kiosk-käytöstä)"
+                  title="Uudet lainat"
+                  description="Ilmoitukset uusista lainoista (myös kiosk-käytöstä)"
                   checked={emailNewLoanNotification}
                   disabled={isSaving}
                   onCheckedChange={(v) => handleEmailPreferenceChange('newLoan', v)}
                 />
                 <PrefRow
                   title="Viikottaiset muistutukset vanhoista bokseista"
-                  description="Muistutukset varauksista, jotka ovat olleet boksissa yli viikon"
+                  description="Muistutukset lainoista, jotka ovat olleet boksissa yli viikon"
                   checked={emailOldBoxNotification}
                   disabled={isSaving}
                   onCheckedChange={(v) => handleEmailPreferenceChange('oldBox', v)}
                 />
                 <PrefRow
-                  title="Myöhässä olevat varaukset"
-                  description="Ilmoitukset varauksista, joiden palautusaika on ylittynyt"
+                  title="Myöhässä olevat lainat"
+                  description="Ilmoitukset lainoista, joiden palautusaika on ylittynyt"
                   checked={emailOverdueNotification}
                   disabled={isSaving}
                   onCheckedChange={(v) => handleEmailPreferenceChange('overdue', v)}
@@ -212,15 +212,15 @@ export default function AccountView({ loans, userEmailPreferences }: AccountView
             ) : (
               <>
                 <PrefRow
-                  title="Ilmoitukset uusista varauksista"
-                  description="Sähköpostit kun luot uuden varauksen"
+                  title="Ilmoitukset uusista lainoista"
+                  description="Sähköpostit kun luot uuden lainan"
                   checked={emailNewLoanNotification}
                   disabled={isSaving}
                   onCheckedChange={(v) => handleEmailPreferenceChange('newLoan', v)}
                 />
                 <PrefRow
-                  title="Muistutukset varauksista"
-                  description="Muistutukset varauksiesi päättymisestä"
+                  title="Muistutukset lainoista"
+                  description="Muistutukset lainojesi päättymisestä"
                   checked={emailWeeklyReminder}
                   disabled={isSaving}
                   onCheckedChange={(v) => handleEmailPreferenceChange('weekly', v)}
@@ -262,7 +262,7 @@ export default function AccountView({ loans, userEmailPreferences }: AccountView
 
         {session?.user?.group !== 'KIOSK' && (
           <div>
-            <h2 className="mb-4 text-xl font-semibold">Oma varaushistoria</h2>
+            <h2 className="mb-4 text-xl font-semibold">Oma lainahistoria</h2>
             {loansSorted.length > 0 ? (
               <div className="flex flex-col gap-4">
                 {loansSorted.map((loan) => (
@@ -270,7 +270,7 @@ export default function AccountView({ loans, userEmailPreferences }: AccountView
                 ))}
               </div>
             ) : (
-              <p className="py-8 text-center text-muted-foreground">Ei varauksia</p>
+              <p className="py-8 text-center text-muted-foreground">Ei lainoja</p>
             )}
           </div>
         )}

--- a/app/admin/boxes/BoxesView.tsx
+++ b/app/admin/boxes/BoxesView.tsx
@@ -62,12 +62,12 @@ export default function BoxesView({ boxes, reports }: BoxesViewProps) {
 
                 <div>
                   <div className="mb-3 flex items-center justify-between">
-                    <p className="text-sm font-semibold">Varaukset</p>
+                    <p className="text-sm font-semibold">Lainat</p>
                     <Badge>{box.loans.length}</Badge>
                   </div>
 
                   {box.loans.length === 0 ? (
-                    <p className="text-sm italic text-muted-foreground">Ei varauksia</p>
+                    <p className="text-sm italic text-muted-foreground">Ei lainoja</p>
                   ) : (
                     <div className="flex flex-col gap-3">
                       {box.loans.map((loan) => (

--- a/app/admin/editLoan/[id]/EditLoanView.tsx
+++ b/app/admin/editLoan/[id]/EditLoanView.tsx
@@ -172,7 +172,7 @@ export default function EditLoanView({ loan, items }: { loan: LoanWithRelations;
     <>
       <Breadcrumbs
         items={[
-          { label: 'Varaukset', href: '/loan' },
+          { label: 'Lainat', href: '/loan' },
           { label: loan.description || 'Ei kuvausta', href: `/loan/${loan.id}` },
           { label: 'Muokkaa' },
         ]}
@@ -299,9 +299,9 @@ export default function EditLoanView({ loan, items }: { loan: LoanWithRelations;
 
         <div className="rounded-lg border bg-card p-6 shadow-xs">
           <div className="mb-4 flex items-center justify-between">
-            <h2 className="text-xl font-semibold">Varaukset</h2>
+            <h2 className="text-xl font-semibold">Lainaukset</h2>
             <Button
-              aria-label="Palauta kaikki varaukset"
+              aria-label="Palauta kaikki lainaukset"
               size="icon-sm"
               variant="ghost"
               onClick={() => setReservations(loan.reservations)}
@@ -312,7 +312,7 @@ export default function EditLoanView({ loan, items }: { loan: LoanWithRelations;
 
           <div className="flex flex-col gap-3">
             {reservations.length === 0 ? (
-              <p className="italic text-muted-foreground">Ei varauksia</p>
+              <p className="italic text-muted-foreground">Ei lainauksia</p>
             ) : (
               reservations.map((reservation) => (
                 <div
@@ -375,7 +375,7 @@ export default function EditLoanView({ loan, items }: { loan: LoanWithRelations;
                         <FaPlus />
                       </Button>
                       <Button
-                        aria-label="Poista varaus"
+                        aria-label="Poista laina"
                         size="icon-sm"
                         variant="ghost"
                         className="text-destructive hover:bg-destructive/10"

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import NextLink from 'next/link';
-import { FaTrash, FaPlus } from 'react-icons/fa';
+import { FaTrash } from 'react-icons/fa';
 import { MdOutlinePassword } from 'react-icons/md';
 import { useSession } from 'next-auth/react';
 import { useState } from 'react';
@@ -176,11 +175,6 @@ export default function AdminPage() {
       <div className="flex flex-col gap-6">
         <div className="flex items-center justify-between">
           <h1 className="text-4xl font-semibold">Admin</h1>
-          <Button asChild variant="success" size="lg" className="gap-2">
-            <NextLink href="/admin/createItem">
-              <FaPlus /> Luo uusi kama
-            </NextLink>
-          </Button>
         </div>
 
         <div className="flex justify-end">

--- a/app/item/[id]/ItemView.tsx
+++ b/app/item/[id]/ItemView.tsx
@@ -113,7 +113,7 @@ export default function ItemView({ item }: { item: ItemWithRelations }) {
         )}
 
         <div className="mt-4">
-          <h2 className="mb-4 text-xl font-semibold">Varaushistoria</h2>
+          <h2 className="mb-4 text-xl font-semibold">Lainahistoria</h2>
           <ReservationTable reservations={item.reservations} />
         </div>
       </div>

--- a/app/kiosk/startloan/StartLoanView.tsx
+++ b/app/kiosk/startloan/StartLoanView.tsx
@@ -131,7 +131,7 @@ const LoanStartCard = ({
             </div>
             <div className="mb-4 rounded-md border bg-muted p-3">
               <p className="leading-relaxed">
-                Tarkista ennen varauksen vahvistamista, että kaikki kamat ovat kunnossa ja
+                Tarkista ennen lainan vahvistamista, että kaikki kamat ovat kunnossa ja
                 mahdolliset vahingot on raportoitu alla olevaan kenttään. (Esim. puuttuvat kiilat,
                 reikä laavussa tms.)
               </p>

--- a/app/loan/[id]/LoanView.tsx
+++ b/app/loan/[id]/LoanView.tsx
@@ -210,13 +210,13 @@ export default function LoanView({
     <>
       <Breadcrumbs
         items={[
-          { label: 'Varaukset', href: '/loan' },
+          { label: 'Lainat', href: '/loan' },
           { label: loan.description || 'Ei kuvausta' },
         ]}
       />
       <div className="flex flex-col gap-6">
         <h1 className="mb-4 text-3xl font-semibold">
-          Varaus: {loan.description || 'Ei kuvausta'}
+          Laina: {loan.description || 'Ei kuvausta'}
         </h1>
 
         <div className="rounded-lg border bg-card p-6">
@@ -397,9 +397,9 @@ export default function LoanView({
         <Dialog open={rejectOpen} onOpenChange={setRejectOpen}>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Hylätäänkö varaus?</DialogTitle>
+              <DialogTitle>Hylätäänkö laina?</DialogTitle>
             </DialogHeader>
-            <p>Varaushakemus hylätään. Oletko varma?</p>
+            <p>Lainahakemus hylätään. Oletko varma?</p>
             <DialogFooter>
               <Button variant="destructive" onClick={rejectLoan}>
                 Hylkää

--- a/app/loan/[id]/page.tsx
+++ b/app/loan/[id]/page.tsx
@@ -11,7 +11,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
     where: { id },
     select: { description: true },
   });
-  return { title: `Varaus: ${loan?.description || 'Ei kuvausta'} | Klapi` };
+  return { title: `Laina: ${loan?.description || 'Ei kuvausta'} | Klapi` };
 }
 
 export default async function LoanPage({ params }: { params: Promise<{ id: string }> }) {

--- a/app/loan/page.tsx
+++ b/app/loan/page.tsx
@@ -42,14 +42,14 @@ export default function LoanListPage() {
 
   if (!session?.user) return <NotAuthenticated />;
   if (isLoading) return <LoadingSpinner fullWidth />;
-  if (error) return <p className="text-destructive">Virhe ladattaessa varauksia</p>;
+  if (error) return <p className="text-destructive">Virhe ladattaessa lainoja</p>;
 
   if (!loans || loans.length === 0) {
     return (
       <div>
-        <h1 className="text-3xl font-semibold">Ei varauksia</h1>
+        <h1 className="text-3xl font-semibold">Ei lainoja</h1>
         <Button asChild className="mt-4">
-          <NextLink href="/">Luo varaus etusivulla</NextLink>
+          <NextLink href="/">Luo laina etusivulla</NextLink>
         </Button>
       </div>
     );
@@ -82,10 +82,10 @@ export default function LoanListPage() {
 
   return (
     <>
-      <Breadcrumbs items={[{ label: 'Varaukset' }]} />
+      <Breadcrumbs items={[{ label: 'Lainat' }]} />
       <div className="flex flex-col gap-8">
         <div>
-          <h1 className="mb-4 text-3xl font-semibold">Varaukset</h1>
+          <h1 className="mb-4 text-3xl font-semibold">Lainat</h1>
           <div className="py-4">
             <div className="flex flex-col gap-3">
               <label className="flex items-center gap-2 font-medium">

--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -225,7 +225,7 @@ export default function CartDrawer({ isOpen, onClose }: { isOpen: boolean; onClo
           {isKiosk && (
             <div className="mt-6 rounded-lg border-2 bg-muted p-4">
               <p className="text-base leading-relaxed">
-                Tarkista ennen varauksen vahvistamista, että kaikki kamat ovat kunnossa ja
+                Tarkista ennen lainan vahvistamista, että kaikki kamat ovat kunnossa ja
                 mahdolliset vahingot on raportoitu alla olevaan kenttään. (Esim. puuttuvat kiilat,
                 reikä laavussa tms.)
               </p>

--- a/components/CustomItemDialog.tsx
+++ b/components/CustomItemDialog.tsx
@@ -42,7 +42,7 @@ export default function CustomItemDialog({ isOpen, onClose }: Props) {
     <Dialog open={isOpen} onOpenChange={(o) => (!o ? onClose() : null)}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Lisää oma kama varaukseen</DialogTitle>
+          <DialogTitle>Lisää oma kama lainaan</DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
           <div>

--- a/components/DateSelector.tsx
+++ b/components/DateSelector.tsx
@@ -68,7 +68,7 @@ export default function DateSelector() {
               className="mt-4 w-full"
               onClick={() => setBrowseMode(true)}
             >
-              Selaa katalogia ilman varausta
+              Selaa katalogia ilman lainaa
             </Button>
           </div>
         </>

--- a/components/KioskModeSelector.tsx
+++ b/components/KioskModeSelector.tsx
@@ -27,7 +27,7 @@ export default function KioskModeSelector() {
         <div className="rounded-lg border border-primary/30 bg-primary/10 p-5 text-base leading-relaxed shadow-xs text-foreground/90">
           <p className="mb-3">
             Merkkaa Klapiin jokainen tavara jonka lainaat. Jos tavara ei löydy Klapista, voit lisätä
-            sen itse varauksen yhteydessä.
+            sen itse lainauksen yhteydessä.
           </p>
           <p className="mb-3">Palauta tavarat sovittuna ajankohtana hyvässä kunnossa.</p>
           <p>
@@ -49,7 +49,7 @@ export default function KioskModeSelector() {
           </Button>
         </div>
         <Button variant="outline" onClick={() => router.push('/kiosk/startloan')}>
-          Merkkaa ennakkoon tehty varaus noudetuksi
+          Merkkaa ennakkoon tehty laina noudetuksi
         </Button>
       </div>
     </div>

--- a/components/LoanerAutocomplete.tsx
+++ b/components/LoanerAutocomplete.tsx
@@ -131,7 +131,7 @@ export default function LoanerAutocomplete({
           )}
         >
           {selectedUserId
-            ? '✓ Käyttäjä valittu. Varaus yhdistetään tähän tiliin.'
+            ? '✓ Käyttäjä valittu. Laina yhdistetään tähän tiliin.'
             : 'Valitse sähköposti listalta tai kirjoita vapaamuotoinen nimi.'}
         </p>
       )}

--- a/components/SubmitConfirmation.tsx
+++ b/components/SubmitConfirmation.tsx
@@ -135,8 +135,8 @@ export default function SubmitConfirmation({
 
       setReportContent('');
       clearCart();
-      toast.success('Varaus lähetetty', {
-        description: 'Varaus rekisteröitiin onnistuneesti.',
+      toast.success('Laina lähetetty', {
+        description: 'Laina rekisteröitiin onnistuneesti.',
         duration: 9000,
       });
       if (session?.user?.group === 'KIOSK') {
@@ -147,7 +147,7 @@ export default function SubmitConfirmation({
         router.push('/account');
       }
     } else {
-      toast.error('Error', { description: 'Varauksen lähetyksessä tapahtui virhe' });
+      toast.error('Error', { description: 'Lainan lähetyksessä tapahtui virhe' });
     }
 
     onClose();
@@ -159,7 +159,7 @@ export default function SubmitConfirmation({
     <Dialog open={isOpen} onOpenChange={(o) => (!o ? onClose() : null)}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Tarkista varauksen tiedot:</DialogTitle>
+          <DialogTitle>Tarkista lainan tiedot:</DialogTitle>
         </DialogHeader>
         <div>
           {inBoxItems.length > 0 && (
@@ -198,7 +198,7 @@ export default function SubmitConfirmation({
               minute: '2-digit',
             })}
           </p>
-          <p className="mt-4">Varattavat kamat:</p>
+          <p className="mt-4">Lainattavat kamat:</p>
 
           <Table>
             <TableHeader>
@@ -223,7 +223,7 @@ export default function SubmitConfirmation({
             Peruuta
           </Button>
           <Button variant="success" onClick={handleSubmit} isLoading={isLoading || isCheckingBox}>
-            Lähetä varaus
+            Lähetä laina
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -248,7 +248,7 @@ export default function TopBar({ children }: { children: ReactNode }) {
               </NextLink>
               {(role === 'ADMIN' || role === 'KIOSK') && (
                 <NextLink href="/loan" className="font-medium text-white">
-                  Varaukset
+                  Lainat
                 </NextLink>
               )}
               {role === 'ADMIN' && (
@@ -322,7 +322,7 @@ export default function TopBar({ children }: { children: ReactNode }) {
             </NextLink>
             {(role === 'ADMIN' || role === 'KIOSK') && (
               <NextLink href="/loan" onClick={onClose} className="px-6 py-4">
-                Varaukset
+                Lainat
               </NextLink>
             )}
             {role === 'ADMIN' && (


### PR DESCRIPTION
## Summary
- Moved the **Luo uusi kama** button out of the Admin page and into the browse-mode header on the **Kamat** view (admin-gated via `session.user.group === 'ADMIN'`).
- Renamed **Varaus / Varaukset** terminology to **Laina / Lainat** across the UI: topbar nav (desktop + mobile), loan list/detail, admin loan edit, boxes view, account notification labels, kiosk start-loan flow, and the submit / cart / custom-item dialogs. Finnish case forms used as needed (Laina, Lainat, Lainan, Lainoja, Lainahistoria, Lainahakemus, Lainaukset).
- Email templates under `app/api/email/*` were intentionally left unchanged — separate concern.

## Test plan
- [ ] Topbar shows **Lainat** (not Varaukset) in both desktop and mobile drawer
- [ ] As admin, clicking **Kamat** in topbar shows the **Luo uusi kama** button next to **Siirry lainaamaan**
- [ ] As non-admin, the **Luo uusi kama** button is not visible on the Kamat view
- [ ] Admin page no longer shows **Luo uusi kama**
- [ ] `/loan` list page heading + breadcrumb read **Lainat**, empty state reads **Ei lainoja**
- [ ] Loan detail page title is **Laina: …**
- [ ] Submit confirmation dialog title, button, and toast use **laina/lainan**
- [ ] Account page section reads **Oma lainahistoria**, notification labels use lainat
- [ ] `pnpm type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)