### PR TITLE
fix(ui): compact loan filter, inline admin header, cart toggle race

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -185,23 +185,19 @@ export default function AdminPage() {
     <>
       <Breadcrumbs items={[{ label: 'Admin' }]} />
       <div className="flex flex-col gap-6">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h1 className="text-4xl font-semibold">Admin</h1>
-        </div>
-
-        <div className="flex justify-end">
-          <Button onClick={getOTP} variant="warning" className="gap-2">
-            <MdOutlinePassword /> Näytä kioskikäyttäjän salasana
-          </Button>
-        </div>
-
-        {!session?.user?.adminExpiry && (
-          <div className="flex justify-end">
-            <Button onClick={() => setPinDialogOpen(true)} variant="warning" className="gap-2">
-              <MdOutlinePassword /> Aseta oma admin-PIN
+          <div className="flex flex-wrap items-center gap-2">
+            <Button onClick={getOTP} variant="warning" className="gap-2">
+              <MdOutlinePassword /> Näytä kioskikäyttäjän salasana
             </Button>
+            {!session?.user?.adminExpiry && (
+              <Button onClick={() => setPinDialogOpen(true)} variant="warning" className="gap-2">
+                <MdOutlinePassword /> Aseta oma admin-PIN
+              </Button>
+            )}
           </div>
-        )}
+        </div>
 
         <Dialog open={pinDialogOpen} onOpenChange={setPinDialogOpen}>
           <DialogContent>

--- a/app/loan/page.tsx
+++ b/app/loan/page.tsx
@@ -83,41 +83,48 @@ export default function LoanListPage() {
   return (
     <>
       <Breadcrumbs items={[{ label: 'Lainat' }]} />
-      <div className="flex flex-col gap-8">
-        <div>
-          <h1 className="mb-4 text-3xl font-semibold">Lainat</h1>
-          <div className="py-4">
-            <div className="flex flex-col gap-3">
-              <label className="flex items-center gap-2 font-medium">
-                <input
-                  type="checkbox"
-                  checked={allChecked}
-                  ref={(el) => {
-                    if (el) el.indeterminate = isIndeterminate;
-                  }}
-                  onChange={toggleAllStatuses}
-                />
-                Kaikki
-              </label>
-              <div className="flex flex-col gap-2 pl-6">
-                {allStatuses.map((status) => (
-                  <label key={status} className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      checked={selectedStatuses.has(status)}
-                      onChange={() => toggleStatus(status)}
-                    />
-                    {getStatusFilterLabel(status)}
-                  </label>
-                ))}
-              </div>
-            </div>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          <h1 className="text-3xl font-semibold">Lainat</h1>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={toggleAllStatuses}
+              aria-pressed={allChecked}
+              className={`rounded-full border px-3 py-1 text-sm font-medium transition ${
+                allChecked
+                  ? 'border-primary bg-primary text-primary-foreground'
+                  : isIndeterminate
+                    ? 'border-primary/50 bg-primary/10 text-foreground'
+                    : 'border-input bg-background text-muted-foreground hover:bg-accent'
+              }`}
+            >
+              Kaikki
+            </button>
+            {allStatuses.map((status) => {
+              const active = selectedStatuses.has(status);
+              return (
+                <button
+                  key={status}
+                  type="button"
+                  onClick={() => toggleStatus(status)}
+                  aria-pressed={active}
+                  className={`rounded-full border px-3 py-1 text-sm transition ${
+                    active
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-input bg-background text-muted-foreground hover:bg-accent'
+                  }`}
+                >
+                  {getStatusFilterLabel(status)}
+                </button>
+              );
+            })}
           </div>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            {filteredLoans.map((loan) => (
-              <LoanCard key={loan.id} loan={loan as LoanType} />
-            ))}
-          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {filteredLoans.map((loan) => (
+            <LoanCard key={loan.id} loan={loan as LoanType} />
+          ))}
         </div>
       </div>
     </>

--- a/components/CartButton.tsx
+++ b/components/CartButton.tsx
@@ -19,6 +19,7 @@ export default function CartButton({ onOpen, onClose, isOpen }: CartButtonProps)
       aria-label="open cart"
       size="icon"
       data-cart-button
+      onPointerDown={(e) => e.stopPropagation()}
       onClick={isOpen ? onClose : onOpen}
       disabled={!dates.datesSet}
     >


### PR DESCRIPTION
## Summary
- Replace stacked checkbox filter on `/loan` with inline toggle pills (incl. a "Kaikki" pill with indeterminate state). Same filter logic, much less vertical space.
- Put admin page title and the kiosk-password / admin-PIN buttons on a single row instead of a vertical stack.
- Stop pointerdown propagation on `CartButton` so Radix's document-level outside-click detection doesn't fire on the button — fixes the glitch where clicking the cart button while the drawer was open failed to close it (Radix would close, then the stale `onClick` branch re-opened).

## Test plan
- [ ] `/loan` filter pills toggle individual statuses; "Kaikki" toggles all and shows indeterminate when partial
- [ ] `/admin` header has title + both buttons on one row at desktop widths, wraps cleanly on narrow widths
- [ ] Cart drawer: open via cart button, then click cart button again — drawer closes cleanly (no flicker / no re-open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)